### PR TITLE
Allow swap-case in oil buffers

### DIFF
--- a/nvim/lua/plugins/oil.lua
+++ b/nvim/lua/plugins/oil.lua
@@ -1,5 +1,9 @@
 local function configure()
-  require("oil").setup()
+  require("oil").setup({
+    keymaps = {
+      ['~'] = false
+    }
+  })
   vim.keymap.set("n", "-", "<cmd>Oil<cr>", { desc = "Browse parent directory" })
 end
 

--- a/nvim/lua/plugins/oil.lua
+++ b/nvim/lua/plugins/oil.lua
@@ -1,7 +1,7 @@
 local function configure()
   require("oil").setup({
     keymaps = {
-      ['~'] = false,
+      ["~"] = false,
     },
   })
   vim.keymap.set("n", "-", "<cmd>Oil<cr>", { desc = "Browse parent directory" })

--- a/nvim/lua/plugins/oil.lua
+++ b/nvim/lua/plugins/oil.lua
@@ -2,7 +2,7 @@ local function configure()
   require("oil").setup({
     keymaps = {
       ['~'] = false,
-    }
+    },
   })
   vim.keymap.set("n", "-", "<cmd>Oil<cr>", { desc = "Browse parent directory" })
 end

--- a/nvim/lua/plugins/oil.lua
+++ b/nvim/lua/plugins/oil.lua
@@ -1,7 +1,7 @@
 local function configure()
   require("oil").setup({
     keymaps = {
-      ['~'] = false
+      ['~'] = false,
     }
   })
   vim.keymap.set("n", "-", "<cmd>Oil<cr>", { desc = "Browse parent directory" })


### PR DESCRIPTION
I found out how to fix oil's capitalization issue. "`" is what I usually use to set cwd. "~" does something similar but I just don't ever find myself using it.